### PR TITLE
fix(pgsql): add support for client_encoding

### DIFF
--- a/src/Db/Core.php
+++ b/src/Db/Core.php
@@ -204,7 +204,11 @@ class Core
                 $dsn .= ';port=' . $this->config('port');
             }
             if ($this->config('charset')) {
-                $dsn .= ';charset=' . $this->config('charset');
+                if($dbtype === 'pgsql') {
+                    $dsn .= ';options=\'--client_encoding='.$this->config('charset').'\'';
+                } else {
+                    $dsn .= ';charset=' . $this->config('charset');
+                }
             }
             if ($this->config('unixSocket')) {
                 $dsn .= ';unix_socket=' . $this->config('unixSocket');


### PR DESCRIPTION
This is a patch for the error `SQLSTATE[08006] [7] invalid connection option "charset"` when connecting to a pgsql instance setting a specific charset.

See [pgsql docs](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-CLIENT-ENCODING) for additional info.

![leaf-db-pgsql](https://github.com/user-attachments/assets/7f5688f7-0c24-40db-b541-1e8377be6a34)
